### PR TITLE
Added HTML link of LHS model to PredictionItem's header

### DIFF
--- a/graphics-items/prediction-item.cpp
+++ b/graphics-items/prediction-item.cpp
@@ -72,7 +72,7 @@ PredictionItem::PredictionItem(
     replicodeObjects,
     parent,
     "Model " + makeHtmlLink(modelReduction->getFactImdl()->get_reference(0)->get_reference(0), replicodeObjects) +
-    " " + RightDoubleArrowHtml + " Prediction"),
+    " " + RightDoubleArrowHtml + "<br>&nbsp;&nbsp;Prediction"),
   modelReduction_(modelReduction), showState_(HIDE_IMDL)
 {
   setFactPredFactMkValHtml();


### PR DESCRIPTION
The LHS model of a prediction item is now shown in the header of the PredicitonItem view.
See issue #4 