### PR TITLE
Dynamic window size setting + scrollbar as needed

### DIFF
--- a/aera-visualizer-window.cpp
+++ b/aera-visualizer-window.cpp
@@ -147,15 +147,15 @@ AeraVisulizerWindow::AeraVisulizerWindow(ReplicodeObjects& replicodeObjects)
   modelsScene_ = new AeraVisualizerScene(replicodeObjects_, this, false,
     [=]() { selectedScene_ = modelsScene_; });
   auto modelsSceneView = new QGraphicsView(modelsScene_, this);
-  modelsSceneView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  modelsSceneView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  modelsSceneView->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+  modelsSceneView->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 
   mainScene_ = new AeraVisualizerScene(replicodeObjects_, this, true,
     [=]() { selectedScene_ = mainScene_; });
   // Use a MyQGraphicsView so that we can track movements to the scene view.
   auto mainSceneView = new MyQGraphicsView(mainScene_, this);
-  mainSceneView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  mainSceneView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  mainSceneView->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+  mainSceneView->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   // Set a default selected scene.
   selectedScene_ = mainScene_;
 

--- a/graphics-items/aera-visualizer-scene.cpp
+++ b/graphics-items/aera-visualizer-scene.cpp
@@ -92,7 +92,20 @@ AeraVisualizerScene::AeraVisualizerScene(
   lineColor_ = Qt::black;
   setBackgroundBrush(QColor(245, 245, 245));
   flashTimerId_ = 0;
-  setSceneRect(QRectF(0, 0, 20000, 20000));
+  
+  // setting the size of scene according to the number of items in the model and main scenes
+  QRectF bounding_rectangle;
+  foreach(QGraphicsItem * item, items()) {
+    if (dynamic_cast<AeraGraphicsItem*>(item) && item->isVisible()) {
+      if (bounding_rectangle.width() == 0)
+        bounding_rectangle = item->sceneBoundingRect();
+      else
+        bounding_rectangle = bounding_rectangle.united(item->sceneBoundingRect());
+    }
+  }
+  int Width_of_Scene = bounding_rectangle.width();
+  int Highet_Of_Scene = bounding_rectangle.height();
+  setSceneRect(QRectF(0, 0, Width_of_Scene, Highet_Of_Scene));
 
   if (isMainScene_) {
     eventTypeFirstTop_[IoDeviceEjectEvent::EVENT_TYPE] = 20;

--- a/graphics-items/aera-visualizer-scene.cpp
+++ b/graphics-items/aera-visualizer-scene.cpp
@@ -93,20 +93,6 @@ AeraVisualizerScene::AeraVisualizerScene(
   setBackgroundBrush(QColor(245, 245, 245));
   flashTimerId_ = 0;
   
-  // setting the size of scene according to the number of items in the model and main scenes
-  QRectF bounding_rectangle;
-  foreach(QGraphicsItem * item, items()) {
-    if (dynamic_cast<AeraGraphicsItem*>(item) && item->isVisible()) {
-      if (bounding_rectangle.width() == 0)
-        bounding_rectangle = item->sceneBoundingRect();
-      else
-        bounding_rectangle = bounding_rectangle.united(item->sceneBoundingRect());
-    }
-  }
-  int Width_of_Scene = bounding_rectangle.width();
-  int Highet_Of_Scene = bounding_rectangle.height();
-  setSceneRect(QRectF(0, 0, Width_of_Scene, Highet_Of_Scene));
-
   if (isMainScene_) {
     eventTypeFirstTop_[IoDeviceEjectEvent::EVENT_TYPE] = 20;
     eventTypeFirstTop_[IoDeviceInjectEvent::EVENT_TYPE] = 45;


### PR DESCRIPTION
In this commit, the `setSceneRect(QRectF(0, 0, 20000, 20000))` is deleted. This way the visualizer automatically adjusts the size of the scenes and avoids creating blank spaces within them. Scrollbars are also added with the policy of "as needed", say, it shows the vertical and horizontal scrollbars whenever the user zooms in.