### PR TITLE
AeraGraphicsItem: Bring to front on mouseclick

### DIFF
--- a/graphics-items/aera-graphics-item.cpp
+++ b/graphics-items/aera-graphics-item.cpp
@@ -435,11 +435,28 @@ void AeraGraphicsItem::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
   QGraphicsPolygonItem::hoverLeaveEvent(event);
 }
 
+void AeraGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent)
+{
+  if (mouseEvent->button() == Qt::LeftButton)
+  {
+    bringToFront();
+  }
+
+  QGraphicsItem::mousePressEvent(mouseEvent);
+}
+
 void AeraGraphicsItem::TextItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
 {
   parent_->parent_->getParent()->textItemHoverMoveEvent(document(), event->pos());
 
   QGraphicsTextItem::hoverMoveEvent(event);
+}
+
+void AeraGraphicsItem::TextItem::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent)
+{
+  // Forward mouse click events to the graphics item itself
+  parent_->mousePressEvent(mouseEvent);
+  QGraphicsTextItem::mousePressEvent(mouseEvent);
 }
 
 }

--- a/graphics-items/aera-graphics-item.hpp
+++ b/graphics-items/aera-graphics-item.hpp
@@ -201,6 +201,7 @@ protected:
 
   protected:
     void hoverMoveEvent(QGraphicsSceneHoverEvent* event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) override;
   };
   friend TextItem;
 
@@ -208,6 +209,7 @@ protected:
   QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
   void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
   void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+  void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) override;
 
   /**
    * Set the textItem_ to the given html and create the border polygon. Connect


### PR DESCRIPTION
Issue #13 mentions that, at a minimum, the items should be brought to the front when dragged.

This pull request always brings items to the front when they are clicked