### PR TITLE
AeraGraphicsItem: Ensure item is visible when dragged

### DIFF
--- a/graphics-items/aera-graphics-item.hpp
+++ b/graphics-items/aera-graphics-item.hpp
@@ -64,6 +64,7 @@ class QGraphicsScene;
 class QTextEdit;
 class QGraphicsSceneMouseEvent;
 class QMenu;
+class QTimer;
 class QGraphicsSceneContextMenuEvent;
 class QStyleOptionGraphicsItem;
 class QWidget;
@@ -210,6 +211,7 @@ protected:
   void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
   void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
   void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) override;
+  void mouseMoveEvent(QGraphicsSceneMouseEvent* mouseEvent) override;
 
   /**
    * Set the textItem_ to the given html and create the border polygon. Connect
@@ -239,6 +241,7 @@ private:
   AeraEvent* aeraEvent_;
   QList<Arrow*> arrows_;
   QList<AnchoredHorizontalLine*> horizontalLines_;
+  QTimer* ensureVisibleTimer_;
 };
 
 }


### PR DESCRIPTION
Note: This pull request is replaced by pull request #23.

This pull request should solve issue #14 

There is a function on the QGraphicsItem called ensureVisible, which attempts to scroll the scene to a position where the item is visible. However, if it is always called on the "mouse move" event, it would cause a stack overflow exception, probably because it would be called too frequently.

To handle that, a timer was created that delays the ensureVisible call, so the item must be kept in the same position momentarily for the scroll functionality to "kick in".

Another issue was that if the viewport size is smaller than the item being moved (like initially in the model scene) the ensureVisible functionality would always try to scroll to the right when an item was picked up. To avoid this case, I disabled the functionality if the width of the viewport is smaller than the item being dragged.