### PR TITLE
Zoom/focus functionality

### DIFF
--- a/aera-visualizer-window.cpp
+++ b/aera-visualizer-window.cpp
@@ -728,6 +728,19 @@ void AeraVisulizerWindow::focusOnAeraGraphicsItem(Code* object)
   }
 }
 
+void AeraVisulizerWindow::centerOnAeraGraphicsItem(Code* object)
+{
+  AeraVisualizerScene* scene;
+  auto item = getAeraGraphicsItem(object, &scene);
+  if (item) {
+    if (item == hoverHighlightItem_ && !hoverHighlightItemWasVisible_)
+      // The item is temporarily visible while hovering. Make sure it stays visible when we un-hover.
+      hoverHighlightItemWasVisible_ = true;
+
+    scene->centerOnItem(item);
+  }
+}
+
 void AeraVisulizerWindow::textItemHoverMoveEvent(const QTextDocument* document, QPointF position)
 {
   auto url = document->documentLayout()->anchorAt(position);

--- a/aera-visualizer-window.hpp
+++ b/aera-visualizer-window.hpp
@@ -139,6 +139,14 @@ public:
    */
    void focusOnAeraGraphicsItem(r_code::Code* object);
 
+    /**
+  * Get the scene AeraGraphicsItem whose getAeraEvent() has the given object, and center on it.
+  * If the item is not found, do nothing. You can use hasAeraGraphicsItem() first to
+  * make sure this will succeed.
+  * \param object The Code* object to search for.
+  */
+    void centerOnAeraGraphicsItem(r_code::Code* object);
+
   /**
    * Handle hover move events to get the HTML link at the position and highlight the linked item
    * until the mouse leaves the link.

--- a/explanation-log-window.cpp
+++ b/explanation-log-window.cpp
@@ -149,6 +149,8 @@ void ExplanationLogWindow::textBrowserAnchorClicked(const QUrl& url)
         [=]() { mainWindow_->zoomToAeraGraphicsItem(object); });
       menu->addAction(QString("Focus on ") + replicodeObjects_.getLabel(object).c_str(),
                       [=]() { mainWindow_->focusOnAeraGraphicsItem(object); });
+      menu->addAction(QString("Center on ") + replicodeObjects_.getLabel(object).c_str(),
+                      [=]() { mainWindow_->centerOnAeraGraphicsItem(object); });
       menu->exec(QCursor::pos() - QPoint(10, 10));
       delete menu;
     }

--- a/graphics-items/aera-graphics-item.cpp
+++ b/graphics-items/aera-graphics-item.cpp
@@ -245,6 +245,23 @@ void AeraGraphicsItem::resetPosition()
     setPos(aeraEvent_->itemInitialTopLeftPosition_ - boundingRect().topLeft());
 }
 
+void AeraGraphicsItem::centerOn()
+{
+  QGraphicsView *qGraphicsView = parent_->views().at(0);
+  QRectF sceneRect = sceneBoundingRect();
+
+  // If the item is wider than the scene, just center on the left part of it
+  if (qGraphicsView->viewport()->width() < sceneRect.width()) {
+    sceneRect.setWidth(qGraphicsView->viewport()->width());
+    qGraphicsView->centerOn(sceneRect.center());
+  }
+  else {
+    qGraphicsView->centerOn(this);
+  }
+  bringToFront();
+  setSelected(true);
+}
+
 void AeraGraphicsItem::ensureVisible()
 {
   QGraphicsView *qGraphicsView = parent_->views().at(0);
@@ -265,6 +282,7 @@ void AeraGraphicsItem::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
   auto menu = new QMenu();
   menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
   menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+  menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
   menu->addAction("Bring To Front", [=]() { bringToFront(); });
   menu->addAction("Send To Back", [=]() { sendToBack(); });
   menu->addAction("Reset Position", [=]() { resetPosition(); });
@@ -408,6 +426,7 @@ void AeraGraphicsItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;
   }
@@ -422,6 +441,8 @@ void AeraGraphicsItem::textItemLinkActivated(const QString& link)
           [=]() { parent_->getParent()->zoomToAeraGraphicsItem(object); });
         menu->addAction(QString("Focus on ") + replicodeObjects_.getLabel(object).c_str(),
                         [=]() { parent_->getParent()->focusOnAeraGraphicsItem(object); });
+        menu->addAction(QString("Center on ") + replicodeObjects_.getLabel(object).c_str(),
+                        [=]() { parent_->getParent()->centerOnAeraGraphicsItem(object); });
         menu->exec(QCursor::pos() - QPoint(10, 10));
         delete menu;
       }

--- a/graphics-items/aera-graphics-item.hpp
+++ b/graphics-items/aera-graphics-item.hpp
@@ -112,6 +112,8 @@ public:
 
   void focus();
 
+  void centerOn();
+
   /**
    * Reset the position to aeraEvent_->itemInitialTopLeftPosition_.
    */

--- a/graphics-items/aera-visualizer-scene.cpp
+++ b/graphics-items/aera-visualizer-scene.cpp
@@ -398,6 +398,16 @@ void AeraVisualizerScene::zoomViewHome()
     views().at(0)->fitInView(boundingRect, Qt::KeepAspectRatio);
 }
 
+void AeraVisualizerScene::centerOnItem(QGraphicsItem *item) {
+  auto aeraGraphicsItem = dynamic_cast<AeraGraphicsItem*>(item);
+  if (aeraGraphicsItem) {
+    if (!aeraGraphicsItem->isVisible())
+      aeraGraphicsItem->setItemAndArrowsAndHorizontalLinesVisible(true);
+
+    aeraGraphicsItem->centerOn();
+  }
+}
+
 void AeraVisualizerScene::focusOnItem(QGraphicsItem* item)
 {
   auto aeraGraphicsItem = dynamic_cast<AeraGraphicsItem*>(item);

--- a/graphics-items/aera-visualizer-scene.hpp
+++ b/graphics-items/aera-visualizer-scene.hpp
@@ -84,6 +84,7 @@ public:
 
   void zoomToItem(QGraphicsItem* item);
   void focusOnItem(QGraphicsItem* item);
+  void centerOnItem(QGraphicsItem* item);
 
   /**
    * Get the X position on the timeline for the given timestamp.

--- a/graphics-items/arrow.cpp
+++ b/graphics-items/arrow.cpp
@@ -120,6 +120,8 @@ void Arrow::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
   menu->addAction("Zoom to End", [=]() { parent_->zoomToItem(endItem_); });
   menu->addAction("Focus on Start", [=]() { parent_->focusOnItem(startItem_); });
   menu->addAction("Focus on End", [=]() { parent_->focusOnItem(endItem_); });
+  menu->addAction("Center on Start", [=]() { parent_->centerOnItem(startItem_); });
+  menu->addAction("Center on End", [=]() { parent_->centerOnItem(endItem_); });
   menu->addAction("Move side-by-side", [=]() { moveEndsSideBySide(); });
   menu->addAction("Show both sides", [=]() { showBothSides(); });
 

--- a/graphics-items/auto-focus-fact-item.cpp
+++ b/graphics-items/auto-focus-fact-item.cpp
@@ -100,6 +100,7 @@ void AutoFocusFactItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     auto fromObject = autoFocusNewObjectEvent_->fromObject_;
     // TODO: How to handle auto focus of the same fact?

--- a/graphics-items/composite-state-goal-item.cpp
+++ b/graphics-items/composite-state-goal-item.cpp
@@ -81,6 +81,7 @@ void CompositeStateGoalItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;

--- a/graphics-items/composite-state-prediction-item.cpp
+++ b/graphics-items/composite-state-prediction-item.cpp
@@ -82,6 +82,7 @@ void CompositeStatePredictionItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;

--- a/graphics-items/drive-item.cpp
+++ b/graphics-items/drive-item.cpp
@@ -79,6 +79,7 @@ void DriveItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;

--- a/graphics-items/model-goal-item.cpp
+++ b/graphics-items/model-goal-item.cpp
@@ -81,6 +81,7 @@ void ModelGoalItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     _Fact* factSuperGoal = modelReduction_->factSuperGoal_;
     _Fact* factValue = (_Fact*)factSuperGoal->get_reference(0)->get_reference(0);

--- a/graphics-items/model-imdl-prediction-item.cpp
+++ b/graphics-items/model-imdl-prediction-item.cpp
@@ -129,6 +129,7 @@ void ImdlPredictionItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
     menu->addAction("What Made This?", [=]() {
       auto pred = modelReduction_->object_->get_reference(0);
       auto factImdl = pred->get_reference(0);

--- a/graphics-items/model-prediction-from-requirement-item.cpp
+++ b/graphics-items/model-prediction-from-requirement-item.cpp
@@ -81,6 +81,7 @@ void ModelPredictionFromRequirementItem::textItemLinkActivated(const QString& li
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;

--- a/graphics-items/model-prediction-item.cpp
+++ b/graphics-items/model-prediction-item.cpp
@@ -81,6 +81,7 @@ void ModelPredictionItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;

--- a/graphics-items/prediction-result-item.cpp
+++ b/graphics-items/prediction-result-item.cpp
@@ -101,6 +101,7 @@ void PredictionResultItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
     menu->addAction("What Made This?", [=]() {
       QString explanation;
       Code* factPrediction = predictionResultEvent_->object_->get_reference(0)->get_reference(0);

--- a/graphics-items/program-output-fact-item.cpp
+++ b/graphics-items/program-output-fact-item.cpp
@@ -99,6 +99,7 @@ void ProgramOutputFactItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
     menu->addAction("What Made This?", [=]() {
       auto mkRdx = programReductionNewObjectEvent_->programReduction_;
 

--- a/graphics-items/promoted-prediction-item.cpp
+++ b/graphics-items/promoted-prediction-item.cpp
@@ -81,6 +81,7 @@ void PromotedPredictionItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;

--- a/graphics-items/simulation-commit-item.cpp
+++ b/graphics-items/simulation-commit-item.cpp
@@ -80,6 +80,7 @@ void SimulationCommitItem::textItemLinkActivated(const QString& link)
     auto menu = new QMenu();
     menu->addAction("Zoom to This", [=]() { parent_->zoomToItem(this); });
     menu->addAction("Focus on This", [=]() { parent_->focusOnItem(this); });
+    menu->addAction("Center on This", [=]() { parent_->centerOnItem(this); });
 
     menu->exec(QCursor::pos() - QPoint(10, 10));
     delete menu;


### PR DESCRIPTION
This pull request is aimed at solving issue #10 and it also solves #14 in a simpler manner than PR #21.

* Changes the zoom functionality to not zoom as far into the main scene (adds a 200x200 margin around the item that is zoomed at), but instead sets the item as selected (which is indicated with dashed borders). The zoom functionality for the models scene is unchanged since the scene is so small as default.

* Adds a focus functionality that centers the scene on the item and sets it as selected, but doesn't change the zoom level at all.

* Scrolls the scene by calling ensureVisible() when an item is dropped. 

I'm not sure if we want to have both the focus and zoom functionality, or if the changed zoom functionality is enough. I added "Focus on Start" and "Focus on End" to the arrow action menu so the functionality can be tested out. 

If we want to keep the focus functionality, it would probably make sense to add it where there is "Zoom to something"  functionality, but I don't see it being very useful where there is "Zoom to This" functionality, since you would already have your attention on the item in those cases. 