### PR TITLE
Auto-scroll for new items

### DIFF
--- a/aera-visualizer-window.cpp
+++ b/aera-visualizer-window.cpp
@@ -137,6 +137,7 @@ const set<int> AeraVisulizerWindow::newItemEventTypes_ = {
   PromotedSimulatedPredictionEvent::EVENT_TYPE,
   PromotedSimulatedPredictionDefeatEvent::EVENT_TYPE };
 
+const QString AeraVisulizerWindow::SettingsKeyAutoScroll = "AutoScroll";
 const QString AeraVisulizerWindow::SettingsKeySimulationsVisible = "simulationsVisible";
 const QString AeraVisulizerWindow::SettingsKeyNonSimulationsVisible = "nonSimulationsVisible";
 const QString AeraVisulizerWindow::SettingsKeyEssenceFactsVisible = "essenceFactsVisible";
@@ -1412,6 +1413,12 @@ void AeraVisulizerWindow::setPlayTime(Timestamp time)
   playTimeLabel_->setText(buffer);
   for (size_t i = 0; i < children_.size(); ++i)
     children_[i]->playTimeLabel_->setText(buffer);
+
+  QSettings settings;
+  // If auto scroll is enabled, ensure the new item is visible
+  if (mainScene_ && settings.value("AutoScroll", Qt::Unchecked).toInt() == Qt::Checked) {
+    mainScene_->scrollToTimestamp(time);
+  }
 }
 
 void AeraVisulizerWindow::setSliderToPlayTime()
@@ -1672,6 +1679,10 @@ void AeraVisulizerWindow::createToolbars()
   toolbar->addAction(zoomInAction_);
   toolbar->addAction(zoomOutAction_);
   toolbar->addAction(zoomHomeAction_);
+
+  toolbar->addSeparator();
+  // Checkbox for auto scroll
+  toolbar->addWidget(new AeraCheckbox("Auto-scroll", SettingsKeyAutoScroll, this));
 
   toolbar->addSeparator();
   toolbar->addWidget(new QLabel("Show/Hide: ", this));

--- a/aera-visualizer-window.hpp
+++ b/aera-visualizer-window.hpp
@@ -258,6 +258,7 @@ private:
   QAction* zoomHomeAction_;
   QAction* zoomToAction_;
 
+  static const QString SettingsKeyAutoScroll;
   static const QString SettingsKeySimulationsVisible;
   static const QString SettingsKeyNonSimulationsVisible;
   static const QString SettingsKeyEssenceFactsVisible;

--- a/graphics-items/aera-visualizer-scene.cpp
+++ b/graphics-items/aera-visualizer-scene.cpp
@@ -442,6 +442,17 @@ void AeraVisualizerScene::zoomToItem(QGraphicsItem* item)
   }
 }
 
+void AeraVisualizerScene::scrollToTimestamp(core::Timestamp timestamp) {
+  auto relativeTime = duration_cast<microseconds>(timestamp - replicodeObjects_.getTimeReference());
+  auto frameStartTime = timestamp - (relativeTime % replicodeObjects_.getSamplingPeriod());
+  qreal xPos = getTimelineX(frameStartTime);
+  // This point marks the top left of the scrolled scene
+  // it is used to keep the same y position while scrolling
+  QGraphicsView* view = views().at(0);
+  QPointF scenePoint = view->mapToScene(QPoint(0,0));
+  view->ensureVisible(xPos, scenePoint.y(), frameWidth_, 0 , 0, 0);
+}
+
 void AeraVisualizerScene::setItemsVisible(int eventType, bool visible)
 {
   foreach(QGraphicsItem * item, items()) {

--- a/graphics-items/aera-visualizer-scene.hpp
+++ b/graphics-items/aera-visualizer-scene.hpp
@@ -85,6 +85,7 @@ public:
   void zoomToItem(QGraphicsItem* item);
   void focusOnItem(QGraphicsItem* item);
   void centerOnItem(QGraphicsItem* item);
+  void scrollToTimestamp(core::Timestamp timestamp);
 
   /**
    * Get the X position on the timeline for the given timestamp.


### PR DESCRIPTION
This pull request is aimed at solving issue #18 

The functionality can be toggled on/off with a new auto-scroll checkbox

I was initially planning on implementing this as just scrolling the scene so the correct timestamp is visible, but that would only work when the new items are placed directly to the right of the current position, and it wouldn't scroll to drives when they are injected.

This implementation calls ensureVisible on all new items, except simulations. This means that it will scroll so the newest item that arrived on the scene is visible and it will show the drives when they are injected.

Do you think this implementation makes sense, or should I rather try to only scroll to the correct place in the timeline?
