### PR TITLE
Add tooltip showing the html of linked items

### DIFF
--- a/graphics-items/aera-graphics-item.cpp
+++ b/graphics-items/aera-graphics-item.cpp
@@ -552,7 +552,24 @@ void AeraGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent)
 
 void AeraGraphicsItem::TextItem::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
 {
-  parent_->parent_->getParent()->textItemHoverMoveEvent(document(), event->pos());
+  auto window = parent_->parent_->getParent();
+  window->textItemHoverMoveEvent(document(), event->pos());
+
+  // If we are hovering a linked item, show the linked item as tooltip
+  auto url = document()->documentLayout()->anchorAt(event->pos());
+  if (url.startsWith("#detail_oid-")) {
+    uint64 detail_oid = url.mid(12).toULongLong();
+    auto object =  parent_->replicodeObjects_.getObjectByDetailOid(detail_oid);
+    if (object) {
+      AeraGraphicsItem *aeraGraphicsItem = window->getAeraGraphicsItem(object);
+      if (aeraGraphicsItem) {
+        parent_->setToolTip(aeraGraphicsItem->getHtml());
+      }
+    }
+  }
+  else {
+    parent_->setToolTip("");
+  }
 
   QGraphicsTextItem::hoverMoveEvent(event);
 }

--- a/graphics-items/aera-graphics-item.hpp
+++ b/graphics-items/aera-graphics-item.hpp
@@ -103,6 +103,7 @@ public:
   void addHorizontalLine(AnchoredHorizontalLine* line) { horizontalLines_.append(line); }
   void updateArrowsAndLines();
   AeraEvent* getAeraEvent() { return aeraEvent_; }
+  QString getHtml() { return textItem_->toHtml(); }
 
   /**
    * Change the Z value of this item to be slightly greater than other colliding AeraGraphicsItems.


### PR DESCRIPTION
This pull request is aimed at solving issue #24

The simplest way that I could find to show a tooltip for the links was to hook into the already implemented highlight functionality and just set the tooltip to the html of the highlighted item.