### PR TITLE
Arrow endpoint highlighting (now on dev)

### DIFF
--- a/graphics-items/arrow.cpp
+++ b/graphics-items/arrow.cpp
@@ -76,7 +76,10 @@ Arrow::Arrow(
 : QGraphicsLineItem(),
   highlightBodyPen_(highlightBodyPen),
   highlightArrowBasePen_(highlightArrowBasePen),
-  highlightArrowTipPen_(highlightArrowTipPen)
+  highlightArrowTipPen_(highlightArrowTipPen),
+  wasSelected_(false),
+  startItemLastPen_(DefaultPen),
+  endItemLastPen_(DefaultPen)
 {
   parent_ = parent;
   startItem_ = startItem;
@@ -188,17 +191,52 @@ void Arrow::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                                cos(angle + -M_PI / 2)),
     angle);
 
-  if (isSelected())
-    painter->setPen(QPen(pen().color(), 4, Qt::SolidLine, Qt::RoundCap, Qt::MiterJoin));
-  else
-    painter->setPen(pen());
+  // If selected, change the border color of the start and end items as well as that of the arrow
+  if (isSelected()) {
+    // Remember the last pen settings if this is the first pass
+    if (!wasSelected_) {
+      startItemLastPen_ = startItem_->pen();
+      endItemLastPen_ = endItem_->pen();
+    }
+
+    // Set the colors for the arrow
+    setPens(Arrow::HighlightedPen, getHighlightArrowBasePen(), getHighlightArrowTipPen());
+    painter->setPen(Arrow::HighlightedPen);
+
+    // Set the colors for the objects on either end
+    startItem_->setPen(Arrow::HighlightedPen);
+    endItem_->setPen(Arrow::HighlightedPen);
+
+    // Keep this updated so we can debounce the deselected state
+    wasSelected_ = true;
+
+  }
+  else {
+    // If we just deselected the arrow, recolor the objects at the ends
+    if (wasSelected_) {
+      // Reset the arrow's pens
+      setPens(Arrow::DefaultPen, Arrow::DefaultPen, Arrow::DefaultPen);
+
+      // Reset the end objects' pens
+      startItem_->setPen(startItemLastPen_);
+      endItem_->setPen(endItemLastPen_);
+
+      // Make sure we only do this once
+      wasSelected_ = false;
+    }
+  }
+
+  // Draw the line
+  painter->setPen(pen());
   painter->setBrush(pen().color());
   painter->drawLine(line());
 
+  // Draw the lower arrowhead
   painter->setPen(arrowBasePen_);
   painter->setBrush(arrowBasePen_.color());
   painter->drawPolygon(arrowBase_);
 
+  // Draw the upper arrowhead
   painter->setPen(arrowTipPen_);
   painter->setBrush(arrowTipPen_.color());
   painter->drawPolygon(arrowTip_);

--- a/graphics-items/arrow.hpp
+++ b/graphics-items/arrow.hpp
@@ -167,6 +167,9 @@ private:
   QPolygonF arrowTip_;
   QPen arrowBasePen_;
   QPen arrowTipPen_;
+  bool wasSelected_;        // Use this to track a "falling edge" on the select state
+  QPen startItemLastPen_;   // Used to restore pen settings after deselection
+  QPen endItemLastPen_;     // Used to restore pen settings after deselection
 };
 
 }


### PR DESCRIPTION
This resolves #12 - it's the same changes as in #41, but now on the correct branch. Arrows will highlight connected objects when selected and restore the objects' pens when deselected. Also updated the coding style to fit the project specifications.