### PR TITLE
Added "Highlight All" and "Fit All" features

### DIFF
--- a/aera-visualizer-window.hpp
+++ b/aera-visualizer-window.hpp
@@ -189,6 +189,14 @@ public:
 
   static const std::set<int> simulationEventTypes_;
 
+  AeraVisualizerScene* getMainScene() {
+    return mainScene_;
+  }
+
+  AeraVisualizerScene* getModelsScene() {
+    return modelsScene_;
+  }
+
 protected:
   /**
    * Set iNextStepEvent to the index in events_ of the next event that stepEvent will process.
@@ -231,8 +239,9 @@ private slots:
   void zoomOut();
   void zoomHome();
   void find();
-  void zoomNext();
-  void zoomPrev();
+  void findNext();
+  void findPrev();
+  void fitAll();
 
 private:
   friend class AeraVisualizerWindowBase;
@@ -295,8 +304,9 @@ private:
   QAction* zoomOutAction_;
   QAction* zoomHomeAction_;
   QAction* findAction_;
-  QAction* zoomNextAction_;
-  QAction* zoomPrevAction_;
+  QAction* findNextAction_;
+  QAction* findPrevAction_;
+  QAction* fitAllAction_;
 
   static const QString SettingsKeyAutoScroll;
   static const QString SettingsKeySimulationsVisible;

--- a/find-dialog.hpp
+++ b/find-dialog.hpp
@@ -83,14 +83,23 @@ class FindDialog : public QDialog
     */
     FindDialog(AeraVisualizerWindow* parentWindow, ReplicodeObjects& replicodeObjects);
 
+    // The stepEvent and unstepEvent functions in AeraVisualizerWindow use this to notify the
+    // find dialog that it should refresh its matches (don't put much here since it's called A LOT)
+    void reportStepEvent() {
+      timeSteppedFlag_ = true;
+      highlightAllFlag_ = true;
+    }
+
   public slots:
     void findNext();
     void findPrev();
+    void fitAll();
 
   private slots:
     void selectCompletion();
     void nextCompletion();
     void prevCompletion();
+    void highlightAllStateChange(bool newState);
 
   private:
     // Autocompleter wordlist (just a static list of built-in objects for now)
@@ -103,13 +112,26 @@ class FindDialog : public QDialog
     };
 
     // Used to update the status message
-    void FindDialog::setStatus(std::string message, bool alert = false);
+    void setStatus(std::string message, bool alert = false);
 
     // Get a new list of matches when there's a change in search term or visible objects
     void updateMatches();
 
     // Helper functions for buttons
     void highlightMatch(AeraGraphicsItem* item);
+
+    // Apply the highlight all effect. This is separate from the state changed handler
+    // so it can be used by other functions without needing to first update the matches
+    void applyHighlightAll(bool highlight);
+
+    // Use this to wipe highlights and search terms
+    void resetState();
+
+    // Catch this so we can unhighlight everything before closing the dialog
+    void reject();
+
+    // A debugging function for inspecting the matches_ vector
+    void printMatches(QString title);
 
     // References to the main window
     AeraVisualizerWindow* parentWindow_;
@@ -121,6 +143,7 @@ class FindDialog : public QDialog
     QCheckBox* wraparound_;
     QCheckBox* skipHidden_;
     QCheckBox* zoomTo_;
+    QCheckBox* highlightAll_;
     QLabel* status_;
 
     // Used to track autocompleter selection
@@ -131,7 +154,10 @@ class FindDialog : public QDialog
     std::string searchTerm_;
     std::vector<AeraGraphicsItem*> matches_;
     int n_ = 0;
-    Timestamp lastMaxTime_;
+
+    // Flags used by updateMatches
+    bool timeSteppedFlag_;    // Set this when any time change has ocurred
+    bool highlightAllFlag_;   // Set this when any refresh of the highlights needed
 };
 }
 

--- a/graphics-items/aera-graphics-item.hpp
+++ b/graphics-items/aera-graphics-item.hpp
@@ -222,6 +222,18 @@ public:
     return parent_;
   }
 
+  /* Helper functions to save/restore original pen when we need to highlight this item */
+  void savePen() {
+    if (borderFlashCountdown_ > 0) // Don't restore the highlight pen
+      savedPen_ = getBorderNoHighlightPen();
+    else
+      savedPen_ = pen();
+  }
+
+  void restorePen() {
+    setPen(savedPen_);
+  }
+
   static const QString DownArrowHtml;
   static const QString RightArrowHtml;
   static const QString RightDoubleArrowHtml;
@@ -322,6 +334,7 @@ private:
   QList<Arrow*> arrows_;
   QList<AnchoredHorizontalLine*> horizontalLines_;
   QColor textItemTextColor_;
+  QPen savedPen_;
 };
 
 }

--- a/graphics-items/aera-visualizer-scene.hpp
+++ b/graphics-items/aera-visualizer-scene.hpp
@@ -135,6 +135,16 @@ public:
       flashTimerId_ = startTimer(200);
   }
 
+  // Anything on this list will be highlighted
+  AeraGraphicsItem* currentMatch_ = NULL;
+  std::vector<AeraGraphicsItem*> allMatches_;
+
+  // Adjusts border weight depending on zoom level
+  void updateHighlights();
+
+  // Reset all boxes to normal
+  void unhighlightAll();
+
 protected:
   void mousePressEvent(QGraphicsSceneMouseEvent* mouseEvent) override;
   void mouseReleaseEvent(QGraphicsSceneMouseEvent* mouseEvent) override;


### PR DESCRIPTION
This addresses #47 by adding the abilities to highlight all found items simultaneously and zoom the view to fit all matches. It also added a new "Find" toolbar to the main window. This involved reworking the highlighting system to adjust border width with zoom level and to use static colors instead of the existing flashing animation.