### PR TITLE
Scroll zoom now centers on mouse

### DIFF
--- a/aera-visualizer-window.cpp
+++ b/aera-visualizer-window.cpp
@@ -1932,11 +1932,21 @@ void AeraVisualizerWindow::closeEvent(QCloseEvent* event) {
 
 void AeraVisualizerWindow::zoomIn()
 {
+  // Make sure zoom is focused on the center of the screen
+  QGraphicsView* view = selectedScene_->views().at(0);
+  view->setTransformationAnchor(QGraphicsView::AnchorViewCenter);
+
+  // Zoom in
   selectedScene_->scaleViewBy(1.09);
 }
 
 void AeraVisualizerWindow::zoomOut()
 {
+  // Make sure zoom is focused on the center of the screen
+  QGraphicsView* view = selectedScene_->views().at(0);
+  view->setTransformationAnchor(QGraphicsView::AnchorViewCenter);
+
+  // Zoom out
   selectedScene_->scaleViewBy(1 / 1.09);
 }
 

--- a/graphics-items/aera-visualizer-scene.cpp
+++ b/graphics-items/aera-visualizer-scene.cpp
@@ -631,6 +631,12 @@ void AeraVisualizerScene::wheelEvent(QGraphicsSceneWheelEvent* event)
   if (event->modifiers() == Qt::ControlModifier) {
     // Accept the event to override other behavior.
     event->accept();
+    QGraphicsView* view = views().at(0);
+    
+    // Zoom around the mouse
+    view->setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+
+    // Scale
     scaleViewBy(pow((double)2, event->delta() / 1000.0));
   }
 }


### PR DESCRIPTION
I added a few lines to `aera-visualizer-scene.cpp` so that zooming with the mouse scroll wheel will zoom in and out anchored on the cursor. All other zoom operations are still anchored to the viewport center so they will behave as normal. This resolves #51.