### PR TITLE
fix: Call addStartupItems in updateObjectsAndEvents

### DIFF
--- a/aera-visualizer-window.cpp
+++ b/aera-visualizer-window.cpp
@@ -2169,6 +2169,8 @@ void AeraVisualizerWindow::updateObjectsAndEvents(bool live)
   findDialog_->setReplicodeObjects(&replicodeObjects_);
   mainScene_->setReplicodeObjects(&replicodeObjects_);
   
+  addStartupItems();
+
   // Some changes only matter during a live run
   if (live) {
     playerView_->setRunTime(milliseconds(settings_.run_time_));

--- a/main.cpp
+++ b/main.cpp
@@ -118,7 +118,6 @@ int main(int argv, char *args[])
   auto findDialog = new FindDialog(&mainWindow);
   mainWindow.setFindWindow(findDialog);
   mainWindow.show();
-  mainWindow.addStartupItems();
 
   return app.exec();
 }


### PR DESCRIPTION
This pull request resolves part of issue #63 to add the seed items to the Models and Composite States window. (We can fix the Raw Data panel in another pull request.) They are added to the window by `addStartupItems`.  The new Visualizer delays the loading of the seed items until it is opened by the menu, therefore calling `addStartupItems` in the `main` function does nothing. This pull request calls it after the seed is loaded in `updateObjectsAndEvents`.